### PR TITLE
Use built-in list annotations for relationships

### DIFF
--- a/backlink_bot/db.py
+++ b/backlink_bot/db.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Optional
 
 from sqlmodel import Field, Relationship, SQLModel, Session, create_engine, select
 
@@ -48,7 +48,7 @@ class Category(SQLModel, table=True):
     is_active: bool = Field(default=True)
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
-    recipes: List["Recipe"] = Relationship(back_populates="category")
+    recipes: list["Recipe"] = Relationship(back_populates="category")
 
 
 class Recipe(SQLModel, table=True):
@@ -66,8 +66,8 @@ class Recipe(SQLModel, table=True):
     is_paused: bool = Field(default=False)
 
     category: Optional[Category] = Relationship(back_populates="recipes")
-    executions: List["Execution"] = Relationship(back_populates="recipe")
-    versions: List["RecipeVersion"] = Relationship(back_populates="recipe")
+    executions: list["Execution"] = Relationship(back_populates="recipe")
+    versions: list["RecipeVersion"] = Relationship(back_populates="recipe")
 
 
 class RecipeVersion(SQLModel, table=True):


### PR DESCRIPTION
## Summary
- switch SQLModel relationship type hints in `db.py` to use builtin list generics
- drop the now-unused `typing.List` import

## Testing
- python -m compileall backlink_bot

------
https://chatgpt.com/codex/tasks/task_e_68d266332bf4833198ad54fad9a487fa