### PR TITLE
Pin bcrypt dependency for passlib compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ The Backlink Creator Bot is a modular automation framework for recording and exe
    pip install -e .
    ```
 
+   > **Note:** The project pins `bcrypt<4` to remain compatible with the version of
+   > `passlib` that provides the default password hashing backends, which is
+   > especially important on Windows where incompatible wheels can fail to
+   > install. A regular `pip install -e .` will resolve the correct version
+   > automatically.
+
    Optionally install Playwright support:
 
    ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "httpx",
     "beautifulsoup4",
     "passlib[bcrypt]",
+    "bcrypt<4",
     "python-multipart",
     "email-validator",
 ]

--- a/tests/test_password_hashing.py
+++ b/tests/test_password_hashing.py
@@ -1,0 +1,11 @@
+"""Smoke tests for password hashing dependencies."""
+
+from passlib.context import CryptContext
+
+
+def test_bcrypt_hash_smoke():
+    """Ensure the configured bcrypt backend can hash and verify passwords."""
+
+    context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+    hashed = context.hash("example-password")
+    assert context.verify("example-password", hashed)


### PR DESCRIPTION
## Summary
- pin bcrypt to <4 so pip resolves a passlib-compatible wheel on all platforms
- document the bcrypt constraint in the installation guide
- add a smoke test to hash and verify passwords via passlib to catch incompatibilities early

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2e899d6b883319a998a68b9013ed3